### PR TITLE
Raise exception on 503 error

### DIFF
--- a/meetup/api.py
+++ b/meetup/api.py
@@ -162,6 +162,8 @@ class Client(object):
             raise exceptions.HttpUnauthorized
         if response.status_code == 404:
             raise exceptions.HttpNotFoundError
+        if response.status_code == 503:
+            raise exceptions.HttpServerError
 
         # If we have two or less remaining calls in the period, wait (if the wait flag is set).
         # I tried only waiting after a 429 error, and ended getting locked out doing parallel testing.


### PR DESCRIPTION
I've seen 503 errors when iterating through large query sets, so raise an exception rather than falling through into the next code block. 