### PR TITLE
Fix setup.py package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ from setuptools import setup, find_packages
 from meetup import __version__
 
 package_data = {
-    'api_specification': ['api_specification/*.json']}
+    'meetup': ['api_specification/*.json']
+}
 
 
 readme_file = io.open('README.rst', encoding='utf-8')


### PR DESCRIPTION
It seems like key should contain package name

currently `api_specification` files are not installed if you run:
`pip install https://github.com/pferate/meetup-api/archive/master.zip`